### PR TITLE
[semver:minor] chore: Update slack for dual notifications

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -17,4 +17,4 @@ display:
   source_url: "https://github.com/signaldevs/slack-orb"
 
 orbs:
-  slack: circleci/slack@4.1.3
+  slack: circleci/slack@4.12.5

--- a/src/commands/notify_failure.yml
+++ b/src/commands/notify_failure.yml
@@ -18,3 +18,14 @@ steps:
   - slack/notify:
       event: fail
       template: FAILED_BUILD_TEMPLATE
+  - slack/notify:
+      event: fail
+      # develop => Staging deploys that could've failed 
+      # main => Staging or Production deploys that could've failed 
+      # master => Production deploy that could've failed
+      # autorelease => Production deploy that could've failed
+      # In each case if there is a failure on these branches it could potentially block production deployments
+      branch_pattern: main, master, autorelease, develop
+      # This is for a new alerts-dev-ops-production channel
+      # The channel is meant for high importance CI/CD alerts that could affect production deployments
+      channel: C05US7T31QR

--- a/src/commands/notify_failure.yml
+++ b/src/commands/notify_failure.yml
@@ -20,8 +20,8 @@ steps:
       template: FAILED_BUILD_TEMPLATE
   - slack/notify:
       event: fail
-      # develop => Staging deploys that could've failed 
-      # main => Staging or Production deploys that could've failed 
+      # develop => Staging deploys that could've failed
+      # main => Staging or Production deploys that could've failed
       # master => Production deploy that could've failed
       # autorelease => Production deploy that could've failed
       # In each case if there is a failure on these branches it could potentially block production deployments


### PR DESCRIPTION
This updates slack for issuing dual notifications on failure. Anything that touches a branch that could block production deploys will notify the alert-dev-ops-production channel

@ryanburr can we pair on testing this tomorrow?